### PR TITLE
cleanup player events after component unmount and keep the play splash if there are no controls

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -229,11 +229,61 @@ var ReactVideoPlay = /** @class */ (function (_super) {
                 _this.handlerMouseLeave();
             }, 3000);
         };
+
+        // player events
+        _this.eventPlay = function () {
+            _this.interval = setInterval(function () {
+                _this.setState({
+                    currentTime: +_this.player.currentTime
+                });
+            }, 100);
+        };
+        _this.eventLoadeddata =  function () {
+            _this.setState({
+                duration: _this.player.duration,
+                loading: false
+            });
+        };
+        _this.eventEnded = function () {
+            _this.setState({
+                adv: true,
+                hideControls: false
+            });
+        };
+        _this.eventCanplay = function () {
+            _this.setState({
+                loading: false
+            });
+        };
+        _this.eventWaiting = function () {
+            _this.setState({
+                loading: true
+            });
+        };
+        _this.eventPause = function () {
+            _this.pause(true);
+        };
+        _this.eventProgress = function () {
+            var currentTime = _this.player.currentTime;
+            var buffer = _this.player.buffered;
+            if (buffer.length > 0 && _this.state.duration > 0) {
+                var currentBuffer = 0;
+                for (var i = 0; i < buffer.length; i++) {
+                    if (buffer.start(i) <= currentTime && currentTime <= buffer.end(i)) {
+                        currentBuffer = i;
+                        break;
+                    }
+                }
+                _this.setState({
+                    progressEnd: buffer.end(currentBuffer)
+                });
+            }
+        };
         return _this;
     }
     ReactVideoPlay.prototype.componentDidMount = function () {
         var _this = this;
-        this.events();
+        this.addEvents();
         this.handlerWindowResize();
         if (this.playerContainer) {
             this.playerContainer.addEventListener('mouseenter', this.handlerMouseEnter);
@@ -262,6 +312,7 @@ var ReactVideoPlay = /** @class */ (function (_super) {
         }
     };
     ReactVideoPlay.prototype.componentWillUnmount = function () {
+        this.removeEvents();
         this.playerContainer.removeEventListener('mouseenter', this.handlerMouseEnter);
         this.playerContainer.removeEventListener('mouseleave', this.handlerMouseLeave);
         this.playerContainer.removeEventListener("webkitfullscreenchange", this.onFullscreenChange);
@@ -295,57 +346,29 @@ var ReactVideoPlay = /** @class */ (function (_super) {
         });
         return defaultStatusSourceIndex;
     };
-    ReactVideoPlay.prototype.events = function () {
-        var _this = this;
+
+    ReactVideoPlay.prototype.addEvents = function () {
         if (this.player) {
-            this.player.addEventListener('play', function () {
-                _this.interval = setInterval(function () {
-                    _this.setState({
-                        currentTime: +_this.player.currentTime
-                    });
-                }, 100);
-            });
-            this.player.addEventListener('loadeddata', function () {
-                _this.setState({
-                    duration: _this.player.duration,
-                    loading: false
-                });
-            });
-            this.player.addEventListener('ended', function () {
-                _this.setState({
-                    adv: true,
-                    hideControls: false
-                });
-            });
-            this.player.addEventListener('canplay', function () {
-                _this.setState({
-                    loading: false
-                });
-            });
-            this.player.addEventListener('waiting', function () {
-                _this.setState({
-                    loading: true
-                });
-            });
-            this.player.addEventListener('pause', function () {
-                _this.pause(true);
-            });
-            this.player.addEventListener("progress", function () {
-                var currentTime = _this.player.currentTime;
-                var buffer = _this.player.buffered;
-                if (buffer.length > 0 && _this.state.duration > 0) {
-                    var currentBuffer = 0;
-                    for (var i = 0; i < buffer.length; i++) {
-                        if (buffer.start(i) <= currentTime && currentTime <= buffer.end(i)) {
-                            currentBuffer = i;
-                            break;
-                        }
-                    }
-                    _this.setState({
-                        progressEnd: buffer.end(currentBuffer)
-                    });
-                }
-            }, false);
+            this.player.addEventListener('play', this.eventPlay);
+            this.player.addEventListener('loadeddata',this.eventLoadeddata);
+            this.player.addEventListener('ended', this.eventEnded);
+            this.player.addEventListener('canplay', this.eventCanplay);
+            this.player.addEventListener('waiting', this.eventWaiting);
+            this.player.addEventListener('pause', this.eventPause);
+            this.player.addEventListener("progress", this.eventProgress, false);
+        }
+    };
+
+    ReactVideoPlay.prototype.removeEvents = function () {
+        if (this.player) {
+            clearInterval(this.interval);
+            this.player.removeEventListener('play', this.eventPlay);
+            this.player.removeEventListener('loadeddata',this.eventLoadeddata);
+            this.player.removeEventListener('ended', this.eventEnded);
+            this.player.removeEventListener('canplay', this.eventCanplay);
+            this.player.removeEventListener('waiting', this.eventWaiting);
+            this.player.removeEventListener('pause', this.eventPause);
+            this.player.removeEventListener("progress", this.eventProgress);
         }
     };
     ReactVideoPlay.prototype.controlsHider = function (timeout) {
@@ -445,7 +468,7 @@ var ReactVideoPlay = /** @class */ (function (_super) {
         if (!this.state.paused) {
             className += " hide";
         }
-        if (!this.state.adv && this.state.paused) {
+        if (!this.props.controls || (!this.state.adv && this.state.paused)) {
             return (React.createElement("div", { onClick: this.handlerPlayStop, className: className }));
         }
     };


### PR DESCRIPTION
- When the player gets unmounted there are multiple errors raised due to the fact that the player events still exists and try to change the component states this will clean up these events 
- It's better to keep the play splash button when there are no controls shown in the options